### PR TITLE
Safety Car Data

### DIFF
--- a/safety_car_predictor_shrinked.csv
+++ b/safety_car_predictor_shrinked.csv
@@ -1,446 +1,446 @@
-year,name,date,weather,num_dnfs,safety_car
-2002,Australian Grand Prix,3/3/2002,dry,12,TRUE
-2002,Malaysian Grand Prix,3/17/2002,dry,9,FALSE
-2002,Brazilian Grand Prix,3/31/2002,dry,11,FALSE
-2002,Emilia Romagna Grand Prix,4/14/2002,dry,10,FALSE
-2002,Spanish Grand Prix,4/28/2002,dry,10,FALSE
-2002,Austrian Grand Prix,5/12/2002,dry,11,TRUE
-2002,Monaco Grand Prix,5/26/2002,dry,10,FALSE
-2002,Canadian Grand Prix,6/9/2002,dry,8,TRUE
-2002,European Grand Prix,6/23/2002,dry,6,FALSE
-2002,British Grand Prix,7/7/2002,heavy_rain,10,FALSE
-2002,French Grand Prix,7/21/2002,dry,8,FALSE
-2002,German Grand Prix,7/28/2002,dry,12,FALSE
-2002,Hungarian Grand Prix,8/18/2002,dry,4,FALSE
-2002,Belgian Grand Prix,9/1/2002,dry,9,FALSE
-2002,Italian Grand Prix,9/15/2002,dry,7,FALSE
-2002,Indianapolis Grand Prix,9/29/2002,dry,4,FALSE
-2002,Japanese Grand Prix,10/13/2002,dry,9,FALSE
-2003,Australian Grand Prix,3/9/2003,dry,9,TRUE
-2003,Malaysian Grand Prix,3/23/2003,dry,7,FALSE
-2003,Brazilian Grand Prix,4/6/2003,heavy_rain,10,TRUE
-2003,Emilia Romagna Grand Prix,4/20/2003,dry,6,FALSE
-2003,Spanish Grand Prix,5/4/2003,dry,8,FALSE
-2003,Austrian Grand Prix,5/18/2003,light_rain,6,TRUE
-2003,Monaco Grand Prix,6/1/2003,dry,6,FALSE
-2003,Canadian Grand Prix,6/15/2003,dry,11,FALSE
-2003,European Grand Prix,6/29/2003,dry,6,FALSE
-2003,French Grand Prix,7/6/2003,dry,3,FALSE
-2003,British Grand Prix,7/20/2003,dry,3,TRUE
-2003,German Grand Prix,8/3/2003,dry,9,FALSE
-2003,Hungarian Grand Prix,8/24/2003,dry,6,FALSE
-2003,Italian Grand Prix,9/14/2003,dry,8,FALSE
-2003,Indianapolis Grand Prix,9/28/2003,heavy_rain,9,FALSE
-2003,Japanese Grand Prix,10/12/2003,dry,4,FALSE
-2004,Australian Grand Prix,3/7/2004,dry,5,FALSE
-2004,Malaysian Grand Prix,3/21/2004,light_rain,5,FALSE
-2004,Bahrain Grand Prix,4/4/2004,dry,4,FALSE
-2004,Emilia Romagna Grand Prix,4/25/2004,dry,5,FALSE
-2004,Spanish Grand Prix,5/9/2004,dry,7,FALSE
-2004,Monaco Grand Prix,5/23/2004,dry,11,FALSE
-2004,European Grand Prix,5/30/2004,dry,5,FALSE
-2004,Canadian Grand Prix,6/13/2004,dry,6,FALSE
-2004,Indianapolis Grand Prix,6/20/2004,dry,11,TRUE
-2004,French Grand Prix,7/4/2004,dry,3,FALSE
-2004,British Grand Prix,7/11/2004,dry,4,FALSE
-2004,German Grand Prix,7/25/2004,dry,3,FALSE
-2004,Hungarian Grand Prix,8/15/2004,dry,5,FALSE
-2004,Belgian Grand Prix,8/29/2004,dry,10,TRUE
-2004,Italian Grand Prix,9/12/2004,light_rain,5,FALSE
-2004,Chinese Grand Prix,9/26/2004,dry,4,FALSE
-2004,Japanese Grand Prix,10/10/2004,dry,4,FALSE
-2004,Brazilian Grand Prix,10/24/2004,dry,3,FALSE
-2005,Australian Grand Prix,3/6/2005,dry,5,FALSE
-2005,Malaysian Grand Prix,3/20/2005,dry,7,FALSE
-2005,Bahrain Grand Prix,4/3/2005,dry,8,FALSE
-2005,Emilia Romagna Grand Prix,4/24/2005,dry,5,FALSE
-2005,Spanish Grand Prix,5/8/2005,dry,6,FALSE
-2005,Monaco Grand Prix,5/22/2005,dry,4,TRUE
-2005,European Grand Prix,5/29/2005,dry,3,FALSE
-2005,Canadian Grand Prix,6/12/2005,dry,8,TRUE
-2005,Indianapolis Grand Prix,6/19/2005,dry,0,FALSE
-2005,French Grand Prix,7/3/2005,dry,5,FALSE
-2005,British Grand Prix,7/10/2005,dry,1,TRUE
-2005,German Grand Prix,7/24/2005,dry,2,FALSE
-2005,Hungarian Grand Prix,7/31/2005,dry,5,FALSE
-2005,Turkish Grand Prix,8/21/2005,dry,5,FALSE
-2005,Italian Grand Prix,9/4/2005,dry,0,FALSE
-2005,Belgian Grand Prix,9/11/2005,dry,7,TRUE
-2005,Brazilian Grand Prix,9/25/2005,dry,5,FALSE
-2005,Japanese Grand Prix,10/9/2005,dry,4,TRUE
-2005,Chinese Grand Prix,10/16/2005,dry,6,TRUE
-2006,Bahrain Grand Prix,3/12/2006,dry,4,FALSE
-2006,Malaysian Grand Prix,3/19/2006,dry,8,FALSE
-2006,Australian Grand Prix,4/2/2006,dry,10,TRUE
-2006,Emilia Romagna Grand Prix,4/3/2006,dry,6,TRUE
-2006,European Grand Prix,5/7/2006,dry,9,FALSE
-2006,Spanish Grand Prix,5/14/2006,dry,6,FALSE
-2006,Monaco Grand Prix,5/28/2006,dry,6,TRUE
-2006,British Grand Prix,6/11/2006,dry,4,FALSE
-2006,Canadian Grand Prix,6/25/2006,dry,8,TRUE
-2006,Indianapolis Grand Prix,7/2/2006,dry,13,TRUE
-2006,French Grand Prix,7/16/2006,dry,6,FALSE
-2006,German Grand Prix,7/30/2006,dry,8,FALSE
-2006,Hungarian Grand Prix,8/6/2006,dry,8,FALSE
-2006,Turkish Grand Prix,8/27/2006,dry,5,TRUE
-2006,Italian Grand Prix,9/10/2006,dry,5,FALSE
-2006,Chinese Grand Prix,10/1/2006,light_rain,5,FALSE
-2006,Japanese Grand Prix,10/8/2006,dry,5,FALSE
-2006,Brazilian Grand Prix,10/22/2006,dry,6,TRUE
-2007,Australian Grand Prix,3/18/2007,dry,5,FALSE
-2007,Malaysian Grand Prix,4/8/2007,dry,4,FALSE
-2007,Bahrain Grand Prix,4/15/2007,dry,7,TRUE
-2007,Spanish Grand Prix,5/13/2007,dry,8,FALSE
-2007,Monaco Grand Prix,5/27/2007,dry,4,FALSE
-2007,Canadian Grand Prix,6/10/2007,dry,8,TRUE
-2007,Indianapolis Grand Prix,6/17/2007,dry,7,FALSE
-2007,French Grand Prix,7/1/2007,dry,5,FALSE
-2007,British Grand Prix,7/8/2007,dry,7,FALSE
-2007,European Grand Prix,7/22/2007,heavy_rain,9,TRUE
-2007,Hungarian Grand Prix,8/5/2007,dry,4,FALSE
-2007,Turkish Grand Prix,8/26/2007,dry,2,FALSE
-2007,Italian Grand Prix,9/9/2007,dry,2,TRUE
-2007,Belgian Grand Prix,9/16/2007,dry,5,FALSE
-2007,Japanese Grand Prix,9/30/2007,heavy_rain,10,TRUE
-2007,Chinese Grand Prix,10/7/2007,light_rain,5,FALSE
-2007,Brazilian Grand Prix,10/21/2007,dry,8,FALSE
-2008,Australian Grand Prix,3/16/2008,dry,14,TRUE
-2008,Malaysian Grand Prix,4/23/2008,dry,5,FALSE
-2008,Bahrain Grand Prix,4/6/2008,dry,3,FALSE
-2008,Spanish Grand Prix,4/27/2008,dry,9,TRUE
-2008,Turkish Grand Prix,5/11/2008,dry,3,TRUE
-2008,Monaco Grand Prix,5/25/2008,light_rain,6,TRUE
-2008,Canadian Grand Prix,6/8/2008,dry,7,TRUE
-2008,French Grand Prix,6/22/2008,light_rain,1,FALSE
-2008,British Grand Prix,7/6/2008,heavy_rain,7,TRUE
-2008,German Grand Prix,7/20/2008,dry,3,TRUE
-2008,Hungarian Grand Prix,8/3/2008,dry,3,FALSE
-2008,European Grand Prix,8/24/2008,dry,3,FALSE
-2008,Belgian Grand Prix,9/7/2008,light_rain,4,FALSE
-2008,Italian Grand Prix,9/14/2008,heavy_rain,1,TRUE
-2008,Singapore Grand Prix,9/28/2008,dry,6,TRUE
-2008,Japanese Grand Prix,10/12/2008,dry,5,FALSE
-2008,Chinese Grand Prix,10/19/2008,dry,3,FALSE
-2008,Brazilian Grand Prix,11/2/2008,heavy_rain,2,TRUE
-2009,Australian Grand Prix,3/29/2009,dry,7,TRUE
-2009,Malaysian Grand Prix,4/5/2009,heavy_rain,5,TRUE
-2009,Chinese Grand Prix,4/19/2009,heavy_rain,4,TRUE
-2009,Bahrain Grand Prix,4/26/2009,dry,1,FALSE
-2009,Spanish Grand Prix,5/10/2009,dry,6,TRUE
-2009,Monaco Grand Prix,5/24/2009,dry,6,FALSE
-2009,Turkish Grand Prix,6/7/2009,dry,2,FALSE
-2009,British Grand Prix,6/21/2009,dry,2,FALSE
-2009,German Grand Prix,7/12/2009,dry,2,FALSE
-2009,Hungarian Grand Prix,7/26/2009,dry,3,FALSE
-2009,European Grand Prix,8/23/2009,dry,3,FALSE
-2009,Belgian Grand Prix,8/30/2009,dry,6,TRUE
-2009,Italian Grand Prix,9/13/2009,dry,6,TRUE
-2009,Singapore Grand Prix,9/27/2009,dry,6,TRUE
-2009,Japanese Grand Prix,10/4/2009,dry,2,TRUE
-2009,Brazilian Grand Prix,10/18/2009,dry,6,TRUE
-2009,Abu Dhabi Grand Prix,11/1/2009,dry,2,FALSE
-2010,Bahrain Grand Prix,3/14/2010,dry,9,FALSE
-2010,Australian Grand Prix,3/28/2010,light_rain,10,TRUE
-2010,Malaysian Grand Prix,4/4/2010,dry,7,FALSE
-2010,Chinese Grand Prix,4/18/2010,light_rain,7,TRUE
-2010,Spanish Grand Prix,5/9/2010,dry,7,FALSE
-2010,Monaco Grand Prix,5/16/2010,dry,12,TRUE
-2010,Turkish Grand Prix,5/30/2010,light_rain,5,FALSE
-2010,Canadian Grand Prix,6/13/2010,dry,5,FALSE
-2010,European Grand Prix,6/27/2010,dry,3,TRUE
-2010,British Grand Prix,7/11/2010,dry,4,TRUE
-2010,German Grand Prix,7/25/2010,dry,5,FALSE
-2010,Hungarian Grand Prix,8/1/2010,dry,5,TRUE
-2010,Belgian Grand Prix,8/29/2010,heavy_rain,4,TRUE
-2010,Italian Grand Prix,9/12/2010,dry,5,FALSE
-2010,Singapore Grand Prix,9/26/2010,dry,9,TRUE
-2010,Japanese Grand Prix,10/10/2010,dry,8,TRUE
-2010,Korean Grand Prix,10/24/2010,heavy_rain,9,TRUE
-2010,Brazilian Grand Prix,11/7/2010,dry,1,FALSE
-2010,Abu Dhabi Grand Prix,11/14/2010,dry,4,TRUE
-2011,Australian Grand Prix,3/27/2011,dry,7,FALSE
-2011,Malaysian Grand Prix,4/10/2011,dry,8,FALSE
-2011,Chinese Grand Prix,4/17/2011,dry,1,FALSE
-2011,Turkish Grand Prix,5/8/2011,dry,2,FALSE
-2011,Spanish Grand Prix,5/22/2011,dry,3,FALSE
-2011,Monaco Grand Prix,5/29/2011,dry,7,TRUE
-2011,Canadian Grand Prix,6/12/2011,heavy_rain,7,TRUE
-2011,European Grand Prix,6/26/2011,dry,0,FALSE
-2011,British Grand Prix,7/10/2011,light_rain,5,FALSE
-2011,German Grand Prix,7/24/2011,light_rain,4,FALSE
-2011,Hungarian Grand Prix,7/31/2011,light_rain,4,FALSE
-2011,Belgian Grand Prix,8/28/2011,dry,5,TRUE
-2011,Italian Grand Prix,9/11/2011,dry,8,TRUE
-2011,Singapore Grand Prix,9/25/2011,dry,4,TRUE
-2011,Japanese Grand Prix,10/9/2011,dry,1,TRUE
-2011,Korean Grand Prix,10/16/2011,light_rain,3,TRUE
-2011,Indian Grand Prix ,10/30/2011,dry,5,FALSE
-2011,Abu Dhabi Grand Prix,11/13/2011,dry,4,FALSE
-2011,Brazilian Grand Prix,11/27/2011,dry,4,FALSE
-2012,Australian Grand Prix,3/18/2012,dry,9,TRUE
-2012,Malaysian Grand Prix,3/25/2012,heavy_rain,3,TRUE
-2012,Chinese Grand Prix,4/15/2012,dry,1,FALSE
-2012,Bahrain Grand Prix,4/22/2012,dry,4,FALSE
-2012,Spanish Grand Prix,5/13/2012,dry,5,FALSE
-2012,Monaco Grand Prix,5/27/2012,light_rain,9,TRUE
-2012,Canadian Grand Prix,6/10/2012,dry,4,FALSE
-2012,European Grand Prix,6/24/2012,dry,6,TRUE
-2012,British Grand Prix,7/8/2012,dry,3,FALSE
-2012,German Grand Prix,7/22/2012,dry,1,FALSE
-2012,Hungarian Grand Prix,7/29/2012,dry,2,FALSE
-2012,Belgian Grand Prix,9/2/2012,dry,6,TRUE
-2012,Italian Grand Prix,9/9/2012,dry,5,FALSE
-2012,Singapore Grand Prix,9/23/2012,dry,6,TRUE
-2012,Japanese Grand Prix,10/7/2012,dry,6,TRUE
-2012,Korean Grand Prix,10/14/2012,dry,4,FALSE
-2012,Indian Grand Prix ,10/28/2012,dry,3,FALSE
-2012,Abu Dhabi Grand Prix,11/4/2012,dry,7,TRUE
-2012,United States Grand Prix,11/18/2012,dry,2,FALSE
-2012,Brazilian Grand Prix,11/25/2012,heavy_rain,6,TRUE
-2013,Australian Grand Prix,3/17/2013,dry,4,FALSE
-2013,Malaysian Grand Prix,3/24/2013,light_rain,6,FALSE
-2013,Chinese Grand Prix,4/14/2013,dry,4,FALSE
-2013,Bahrain Grand Prix,4/21/2013,dry,1,FALSE
-2013,Spanish Grand Prix,5/12/2013,dry,3,FALSE
-2013,Monaco Grand Prix,5/26/2013,dry,7,TRUE
-2013,Canadian Grand Prix,6/9/2013,dry,3,FALSE
-2013,British Grand Prix,6/30/2013,dry,4,TRUE
-2013,German Grand Prix,7/7/2013,dry,3,TRUE
-2013,Hungarian Grand Prix,7/28/2013,dry,5,FALSE
-2013,Belgian Grand Prix,8/25/2013,dry,3,FALSE
-2013,Italian Grand Prix,9/8/2013,dry,2,FALSE
-2013,Singapore Grand Prix,9/22/2013,dry,3,TRUE
-2013,Korean Grand Prix,10/6/2013,dry,5,TRUE
-2013,Japanese Grand Prix,10/13/2013,dry,3,FALSE
-2013,Indian Grand Prix ,10/27/2013,dry,4,FALSE
-2013,Abu Dhabi Grand Prix,11/3/2013,dry,1,FALSE
-2013,United States Grand Prix,11/17/2013,dry,1,TRUE
-2013,Brazilian Grand Prix,11/24/2013,dry,3,FALSE
-2014,Australian Grand Prix,3/16/2014,dry,7,TRUE
-2014,Malaysian Grand Prix,3/30/2014,dry,6,FALSE
-2014,Bahrain Grand Prix,4/6/2014,dry,6,TRUE
-2014,Chinese Grand Prix,4/20/2014,dry,2,FALSE
-2014,Spanish Grand Prix,5/11/2014,dry,2,FALSE
-2014,Monaco Grand Prix,5/25/2014,dry,7,TRUE
-2014,Canadian Grand Prix,6/8/2014,dry,9,TRUE
-2014,Austrian Grand Prix,6/22/2014,dry,3,FALSE
-2014,British Grand Prix,7/6/2014,dry,6,TRUE
-2014,German Grand Prix,7/20/2014,dry,4,TRUE
-2014,Hungarian Grand Prix,7/27/2014,light_rain,6,TRUE
-2014,Belgian Grand Prix,8/24/2014,dry,5,FALSE
-2014,Italian Grand Prix,9/7/2014,dry,2,FALSE
-2014,Singapore Grand Prix,9/21/2014,dry,4,TRUE
-2014,Japanese Grand Prix,10/5/2014,heavy_rain,2,TRUE
-2014,Russian Grand Prix,10/12/2014,dry,2,FALSE
-2014,United States Grand Prix,11/2/2014,dry,3,TRUE
-2014,Brazilian Grand Prix,11/9/2014,dry,2,FALSE
-2014,Abu Dhabi Grand Prix,11/23/2014,dry,3,FALSE
-2015,Monaco Grand Prix,5/24/2015,dry,3,TRUE
-2015,Canadian Grand Prix,6/7/2015,dry,3,FALSE
-2015,Bahrain Grand Prix,4/19/2015,dry,2,FALSE
-2015,Spanish Grand Prix,5/10/2015,dry,2,FALSE
-2015,Chinese Grand Prix,4/12/2015,dry,4,TRUE
-2015,Australian Grand Prix,3/15/2015,dry,4,TRUE
-2015,Malaysian Grand Prix,3/29/2015,dry,4,TRUE
-2015,Austrian Grand Prix,6/21/2015,dry,6,TRUE
-2015,British Grand Prix,7/5/2015,light_rain,6,TRUE
-2015,Hungarian Grand Prix,7/26/2015,dry,5,TRUE
-2015,Belgian Grand Prix,8/23/2015,dry,4,TRUE
-2015,Italian Grand Prix,9/6/2015,dry,4,FALSE
-2015,Singapore Grand Prix,9/20/2015,dry,5,TRUE
-2015,Japanese Grand Prix,9/27/2015,dry,1,FALSE
-2015,Russian Grand Prix,10/11/2015,dry,7,TRUE
-2015,United States Grand Prix,10/25/2015,light_rain,8,TRUE
-2015,Mexican Grand Prix,11/1/2015,dry,4,TRUE
-2015,Brazilian Grand Prix,11/15/2015,dry,1,FALSE
-2015,Abu Dhabi Grand Prix,11/29/2015,dry,1,FALSE
-2016,Australian Grand Prix,3/20/2016,dry,5,TRUE
-2016,Bahrain Grand Prix,4/3/2016,dry,3,FALSE
-2016,Chinese Grand Prix,4/17/2016,dry,0,TRUE
-2016,Russian Grand Prix,5/1/2016,dry,4,TRUE
-2016,Spanish Grand Prix,5/15/2016,dry,5,TRUE
-2016,Monaco Grand Prix,5/29/2016,light_rain,7,TRUE
-2016,Canadian Grand Prix,6/12/2016,dry,3,TRUE
-2016,Azerbaijan Grand Prix,6/19/2016,dry,4,FALSE
-2016,Austrian Grand Prix,7/3/2016,dry,6,TRUE
-2016,British Grand Prix,7/10/2016,light_rain,6,TRUE
-2016,Hungarian Grand Prix,7/24/2016,dry,1,FALSE
-2016,German Grand Prix,7/31/2016,dry,2,FALSE
-2016,Belgian Grand Prix,8/28/2016,dry,5,TRUE
-2016,Italian Grand Prix,9/4/2016,dry,4,FALSE
-2016,Singapore Grand Prix,9/18/2016,dry,3,TRUE
-2016,Malaysian Grand Prix,10/2/2016,dry,6,FALSE
-2016,Japanese Grand Prix,10/9/2016,dry,0,FALSE
-2016,United States Grand Prix,10/23/2016,dry,4,TRUE
-2016,Mexican Grand Prix,10/30/2016,dry,1,TRUE
-2016,Brazilian Grand Prix,11/13/2016,heavy_rain,5,TRUE
-2016,Abu Dhabi Grand Prix,11/27/2016,dry,5,FALSE
-2017,Australian Grand Prix,3/26/2017,dry,7,FALSE
-2017,Chinese Grand Prix,4/9/2017,light_rain,5,TRUE
-2017,Bahrain Grand Prix,4/16/2017,dry,6,TRUE
-2017,Russian Grand Prix,4/30/2017,dry,3,TRUE
-2017,Spanish Grand Prix,5/14/2017,dry,3,TRUE
-2017,Monaco Grand Prix,5/28/2017,dry,7,TRUE
-2017,Canadian Grand Prix,6/11/2017,dry,5,TRUE
-2017,Azerbaijan Grand Prix,6/25/2017,dry,7,TRUE
-2017,Austrian Grand Prix,7/9/2017,dry,4,FALSE
-2017,British Grand Prix,7/16/2017,dry,2,TRUE
-2017,Hungarian Grand Prix,7/30/2017,dry,4,TRUE
-2017,Belgian Grand Prix,8/27/2017,dry,4,TRUE
-2017,Italian Grand Prix,9/3/2017,dry,4,FALSE
-2017,Singapore Grand Prix,9/17/2017,light_rain,8,TRUE
-2017,Malaysian Grand Prix,10/1/2017,dry,1,FALSE
-2017,Japanese Grand Prix,10/8/2017,dry,5,TRUE
-2017,United States Grand Prix,10/22/2017,dry,4,FALSE
-2017,Mexican Grand Prix,10/29/2017,dry,5,TRUE
-2017,Brazilian Grand Prix,11/12/2017,dry,4,TRUE
-2017,Abu Dhabi Grand Prix,11/26/2017,dry,2,FALSE
-2018,Australian Grand Prix,3/25/2018,dry,5,TRUE
-2018,Bahrain Grand Prix,4/8/2018,dry,3,TRUE
-2018,Chinese Grand Prix,4/15/2018,dry,1,TRUE
-2018,Azerbaijan Grand Prix,4/29/2018,dry,7,TRUE
-2018,Spanish Grand Prix,5/13/2018,dry,6,TRUE
-2018,Monaco Grand Prix,5/27/2018,dry,3,TRUE
-2018,Canadian Grand Prix,6/10/2018,dry,3,TRUE
-2018,French Grand Prix,6/24/2018,dry,5,TRUE
-2018,Austrian Grand Prix,7/1/2018,dry,6,TRUE
-2018,British Grand Prix,7/8/2018,dry,6,TRUE
-2018,German Grand Prix,7/22/2018,light_rain,5,TRUE
-2018,Hungarian Grand Prix,7/29/2018,dry,3,TRUE
-2018,Belgian Grand Prix,8/26/2018,dry,5,TRUE
-2018,Italian Grand Prix,9/2/2018,dry,3,TRUE
-2018,Singapore Grand Prix,9/16/2018,dry,1,TRUE
-2018,Russian Grand Prix,9/30/2018,dry,2,FALSE
-2018,Japanese Grand Prix,10/7/2018,dry,3,TRUE
-2018,United States Grand Prix,10/21/2018,dry,4,TRUE
-2018,Mexican Grand Prix,10/28/2018,dry,4,TRUE
-2018,Brazilian Grand Prix,11/11/2018,dry,2,FALSE
-2018,Abu Dhabi Grand Prix,11/25/2018,dry,5,TRUE
-2019,Australian Grand Prix,3/17/2019,dry,3,FALSE
-2019,Bahrain Grand Prix,3/31/2019,dry,4,TRUE
-2019,Chinese Grand Prix,4/14/2019,dry,3,TRUE
-2019,Azerbaijan Grand Prix,4/28/2019,dry,4,TRUE
-2019,Spanish Grand Prix,5/12/2019,dry,2,TRUE
-2019,Monaco Grand Prix,5/26/2019,dry,1,TRUE
-2019,Canadian Grand Prix,6/9/2019,dry,2,FALSE
-2019,French Grand Prix,6/23/2019,dry,1,TRUE
-2019,Austrian Grand Prix,6/30/2019,dry,0,FALSE
-2019,British Grand Prix,7/14/2019,dry,3,TRUE
-2019,German Grand Prix,7/28/2019,light_rain,7,TRUE
-2019,Hungarian Grand Prix,8/4/2019,dry,1,FALSE
-2019,Belgian Grand Prix,9/1/2019,dry,3,TRUE
-2019,Italian Grand Prix,9/8/2019,dry,3,TRUE
-2019,Singapore Grand Prix,9/22/2019,dry,3,TRUE
-2019,Russian Grand Prix,9/29/2019,dry,5,TRUE
-2019,Japanese Grand Prix,10/13/2019,dry,1,FALSE
-2019,Mexican Grand Prix,10/27/2019,dry,2,TRUE
-2019,United States Grand Prix,11/3/2019,dry,3,FALSE
-2019,Brazilian Grand Prix,11/17/2019,dry,4,TRUE
-2019,Abu Dhabi Grand Prix,12/1/2019,dry,1,FALSE
-2020,Austrian Grand Prix,7/5/2020,dry,9,TRUE
-2020,Austrian Grand Prix,7/12/2020,dry,3,TRUE
-2020,Hungarian Grand Prix,7/19/2020,light_rain,1,FALSE
-2020,British Grand Prix,8/2/2020,dry,3,TRUE
-2020,British Grand Prix,8/9/2020,dry,1,FALSE
-2020,Spanish Grand Prix,8/16/2020,dry,1,FALSE
-2020,Belgian Grand Prix,8/30/2020,dry,3,TRUE
-2020,Italian Grand Prix,9/6/2020,dry,4,TRUE
-2020,Tuscan Grand Prix,9/13/2020,dry,8,TRUE
-2020,Russian Grand Prix,9/27/2020,dry,2,TRUE
-2020,Eifel Grand Prix,10/11/2020,dry,5,TRUE
-2020,Portuguese Grand Prix,10/25/2020,dry,1,FALSE
-2020,Emilia Romagna Grand Prix,11/1/2020,dry,5,TRUE
-2020,Turkish Grand Prix,11/15/2020,heavy_rain,4,TRUE
-2020,Bahrain Grand Prix,11/29/2020,dry,3,TRUE
-2020,Bahrain Grand Prix,12/6/2020,dry,3,TRUE
-2020,Abu Dhabi Grand Prix,12/13/2020,dry,1,TRUE
-2021,Emilia Romagna Grand Prix,4/18/2021,heavy_rain,3,TRUE
-2021,Bahrain Grand Prix,3/28/2021,dry,4,TRUE
-2021,Qatar Grand Prix,11/21/2021,dry,2,TRUE
-2021,Portuguese Grand Prix,5/2/2021,dry,1,TRUE
-2021,Spanish Grand Prix,5/9/2021,dry,1,TRUE
-2021,Monaco Grand Prix,5/23/2021,dry,2,FALSE
-2021,Azerbaijan Grand Prix,6/6/2021,dry,4,TRUE
-2021,Austrian Grand Prix,6/27/2021,light_rain,2,FALSE
-2021,French Grand Prix,6/20/2021,dry,0,TRUE
-2021,Austrian Grand Prix,7/4/2021,dry,1,TRUE
-2021,British Grand Prix,7/18/2021,dry,2,TRUE
-2021,Hungarian Grand Prix,8/1/2021,light_rain,7,TRUE
-2021,Belgian Grand Prix,8/29/2021,heavy_rain,5,TRUE
-2021,Dutch Grand Prix,9/5/2021,dry,2,FALSE
-2021,Italian Grand Prix,9/12/2021,dry,5,TRUE
-2021,Russian Grand Prix,9/26/2021,light_rain,2,FALSE
-2021,Turkish Grand Prix,10/10/2021,light_rain,0,FALSE
-2021,United States Grand Prix,10/24/2021,dry,3,TRUE
-2021,Mexico City Grand Prix,11/7/2021,dry,2,TRUE
-2021,Sao Paulo Grand Prix,11/14/2021,dry,2,TRUE
-2021,Saudi Arabian Grand Prix,12/5/2021,dry,5,TRUE
-2021,Abu Dhabi Grand Prix,12/12/2021,dry,4,TRUE
-2022,Bahrain Grand Prix,3/20/2022,dry,2,TRUE
-2022,Saudi Arabian Grand Prix,3/27/2022,dry,7,TRUE
-2022,Australian Grand Prix,4/10/2022,dry,3,TRUE
-2022,Emilia Romagna Grand Prix,4/24/2022,light_rain,2,TRUE
-2022,Miami Grand Prix,5/8/2022,dry,4,TRUE
-2022,Spanish Grand Prix,5/22/2022,dry,2,FALSE
-2022,Monaco Grand Prix,5/29/2022,light_rain,3,TRUE
-2022,Azerbaijan Grand Prix,6/12/2022,dry,5,TRUE
-2022,Canadian Grand Prix,6/19/2022,dry,3,TRUE
-2022,British Grand Prix,7/3/2022,dry,6,TRUE
-2022,Austrian Grand Prix,7/10/2022,dry,3,TRUE
-2022,French Grand Prix,7/24/2022,dry,5,TRUE
-2022,Hungarian Grand Prix,7/31/2022,dry,1,TRUE
-2022,Belgian Grand Prix,8/28/2022,dry,2,TRUE
-2022,Dutch Grand Prix,9/4/2022,dry,2,TRUE
-2022,Italian Grand Prix,9/11/2022,dry,4,TRUE
-2022,Singapore Grand Prix,10/2/2022,light_rain,6,TRUE
-2022,Japanese Grand Prix,10/9/2022,heavy_rain,2,TRUE
-2022,United States Grand Prix,10/23/2022,dry,3,TRUE
-2022,Mexico City Grand Prix,10/30/2022,dry,2,TRUE
-2022,Sao Paulo Grand Prix,11/13/2022,dry,3,TRUE
-2022,Abu Dhabi Grand Prix,11/20/2022,dry,3,FALSE
-2023,Bahrain Grand Prix,3/5/2023,dry,3,TRUE
-2023,Saudi Arabian Grand Prix,3/19/2023,dry,2,TRUE
-2023,Australian Grand Prix,4/2/2023,dry,8,TRUE
-2023,Azerbaijan Grand Prix,4/30/2023,dry,2,TRUE
-2023,Miami Grand Prix,5/7/2023,dry,0,FALSE
-2023,Monaco Grand Prix,5/28/2023,heavy_rain,2,FALSE
-2023,Spanish Grand Prix,6/4/2023,dry,0,FALSE
-2023,Canadian Grand Prix,6/18/2023,dry,2,TRUE
-2023,Austrian Grand Prix,7/2/2023,dry,1,TRUE
-2023,British Grand Prix,7/9/2023,dry,3,TRUE
-2023,Hungarian Grand Prix,7/23/2023,dry,3,FALSE
-2023,Belgian Grand Prix,7/30/2023,dry,2,TRUE
-2023,Dutch Grand Prix,8/27/2023,light_rain,3,TRUE
-2023,Italian Grand Prix,9/3/2023,dry,2,FALSE
-2023,Singapore Grand Prix,9/17/2023,dry,4,TRUE
-2023,Japanese Grand Prix,9/24/2023,dry,5,TRUE
-2023,Qatar Grand Prix,10/8/2023,dry,2,TRUE
-2023,United States Grand Prix,10/22/2023,dry,3,FALSE
-2023,Mexico City Grand Prix,10/29/2023,dry,4,TRUE
-2023,Sao Paulo Grand Prix,11/5/2023,dry,6,TRUE
-2023,Las Vegas Grand Prix,11/19/2023,dry,3,TRUE
-2023,Abu Dhabi Grand Prix,11/26/2023,dry,0,FALSE
-2024,Bahrain Grand Prix,3/2/2024,dry,0,FALSE
-2024,Saudi Arabian Grand Prix,3/9/2024,dry,2,TRUE
-2024,Australian Grand Prix,3/24/2024,dry,3,TRUE
-2024,Japanese Grand Prix,4/7/2024,dry,3,TRUE
-2024,Chinese Grand Prix,4/21/2024,dry,3,TRUE
-2024,Miami Grand Prix,5/5/2024,dry,1,TRUE
-2024,Emilia Romagna Grand Prix,5/19/2024,dry,1,FALSE
-2024,Monaco Grand Prix,5/26/2024,dry,4,TRUE
-2024,Canadian Grand Prix,6/9/2024,light_rain,5,TRUE
-2024,Spanish Grand Prix,6/23/2024,dry,0,FALSE
-2024,Austrian Grand Prix,6/30/2024,dry,1,TRUE
-2024,British Grand Prix,7/7/2024,light_rain,2,FALSE
-2024,Hungarian Grand Prix,7/21/2024,dry,1,FALSE
-2024,Belgian Grand Prix,7/28/2024,dry,2,FALSE
-2024,Dutch Grand Prix,8/25/2024,dry,0,FALSE
-2024,Italian Grand Prix,9/1/2024,dry,1,FALSE
-2024,Azerbaijan Grand Prix,9/15/2024,dry,4,TRUE
-2024,Singapore Grand Prix,9/22/2024,dry,2,FALSE
-2024,United States Grand Prix,10/20/2024,dry,1,TRUE
-2024,Mexico City Grand Prix,10/27/2024,dry,3,TRUE
-2024,Sao Paulo Grand Prix,11/3/2024,heavy_rain,5,TRUE
-2024,Las Vegas Grand Prix,11/23/2024,dry,2,FALSE
-2024,Qatar Grand Prix,12/1/2024,dry,5,TRUE
-2024,Abu Dhabi Grand Prix,12/8/2024,dry,4,TRUE
+year,name,date,weather,num_dnfs,safety_car,num_of_sc,num_of_vsc,total
+2002,Australian Grand Prix,3/3/2002,dry,12,TRUE,2,,
+2002,Malaysian Grand Prix,3/17/2002,dry,9,FALSE,,,
+2002,Brazilian Grand Prix,3/31/2002,dry,11,FALSE,,,
+2002,Emilia Romagna Grand Prix,4/14/2002,dry,10,FALSE,0,,
+2002,Spanish Grand Prix,4/28/2002,dry,10,FALSE,,,
+2002,Austrian Grand Prix,5/12/2002,dry,11,TRUE,,,
+2002,Monaco Grand Prix,5/26/2002,dry,10,FALSE,0,,
+2002,Canadian Grand Prix,6/9/2002,dry,8,TRUE,,,
+2002,European Grand Prix,6/23/2002,dry,6,FALSE,,,
+2002,British Grand Prix,7/7/2002,heavy_rain,10,FALSE,,,
+2002,French Grand Prix,7/21/2002,dry,8,FALSE,,,
+2002,German Grand Prix,7/28/2002,dry,12,FALSE,,,
+2002,Hungarian Grand Prix,8/18/2002,dry,4,FALSE,,,
+2002,Belgian Grand Prix,9/1/2002,dry,9,FALSE,,,
+2002,Italian Grand Prix,9/15/2002,dry,7,FALSE,,,
+2002,Indianapolis Grand Prix,9/29/2002,dry,4,FALSE,,,
+2002,Japanese Grand Prix,10/13/2002,dry,9,FALSE,0,,
+2003,Australian Grand Prix,3/9/2003,dry,9,TRUE,2,,
+2003,Malaysian Grand Prix,3/23/2003,dry,7,FALSE,,,
+2003,Brazilian Grand Prix,4/6/2003,heavy_rain,10,TRUE,,,
+2003,Emilia Romagna Grand Prix,4/20/2003,dry,6,FALSE,0,,
+2003,Spanish Grand Prix,5/4/2003,dry,8,FALSE,,,
+2003,Austrian Grand Prix,5/18/2003,light_rain,6,TRUE,,,
+2003,Monaco Grand Prix,6/1/2003,dry,6,FALSE,0,,
+2003,Canadian Grand Prix,6/15/2003,dry,11,FALSE,,,
+2003,European Grand Prix,6/29/2003,dry,6,FALSE,,,
+2003,French Grand Prix,7/6/2003,dry,3,FALSE,,,
+2003,British Grand Prix,7/20/2003,dry,3,TRUE,,,
+2003,German Grand Prix,8/3/2003,dry,9,FALSE,,,
+2003,Hungarian Grand Prix,8/24/2003,dry,6,FALSE,,,
+2003,Italian Grand Prix,9/14/2003,dry,8,FALSE,,,
+2003,Indianapolis Grand Prix,9/28/2003,heavy_rain,9,FALSE,,,
+2003,Japanese Grand Prix,10/12/2003,dry,4,FALSE,0,,
+2004,Australian Grand Prix,3/7/2004,dry,5,FALSE,0,,
+2004,Malaysian Grand Prix,3/21/2004,light_rain,5,FALSE,,,
+2004,Bahrain Grand Prix,4/4/2004,dry,4,FALSE,,,
+2004,Emilia Romagna Grand Prix,4/25/2004,dry,5,FALSE,0,,
+2004,Spanish Grand Prix,5/9/2004,dry,7,FALSE,,,
+2004,Monaco Grand Prix,5/23/2004,dry,11,TRUE,2,,
+2004,European Grand Prix,5/30/2004,dry,5,FALSE,,,
+2004,Canadian Grand Prix,6/13/2004,dry,6,FALSE,,,
+2004,Indianapolis Grand Prix,6/20/2004,dry,11,TRUE,,,
+2004,French Grand Prix,7/4/2004,dry,3,FALSE,,,
+2004,British Grand Prix,7/11/2004,dry,4,FALSE,,,
+2004,German Grand Prix,7/25/2004,dry,3,FALSE,,,
+2004,Hungarian Grand Prix,8/15/2004,dry,5,FALSE,,,
+2004,Belgian Grand Prix,8/29/2004,dry,10,TRUE,,,
+2004,Italian Grand Prix,9/12/2004,light_rain,5,FALSE,,,
+2004,Chinese Grand Prix,9/26/2004,dry,4,FALSE,0,,
+2004,Japanese Grand Prix,10/10/2004,dry,4,FALSE,0,,
+2004,Brazilian Grand Prix,10/24/2004,dry,3,FALSE,,,
+2005,Australian Grand Prix,3/6/2005,dry,5,FALSE,0,,
+2005,Malaysian Grand Prix,3/20/2005,dry,7,FALSE,,,
+2005,Bahrain Grand Prix,4/3/2005,dry,8,FALSE,,,
+2005,Emilia Romagna Grand Prix,4/24/2005,dry,5,FALSE,0,,
+2005,Spanish Grand Prix,5/8/2005,dry,6,FALSE,,,
+2005,Monaco Grand Prix,5/22/2005,dry,4,TRUE,1,,
+2005,European Grand Prix,5/29/2005,dry,3,FALSE,,,
+2005,Canadian Grand Prix,6/12/2005,dry,8,TRUE,,,
+2005,Indianapolis Grand Prix,6/19/2005,dry,0,FALSE,,,
+2005,French Grand Prix,7/3/2005,dry,5,FALSE,,,
+2005,British Grand Prix,7/10/2005,dry,1,TRUE,,,
+2005,German Grand Prix,7/24/2005,dry,2,FALSE,,,
+2005,Hungarian Grand Prix,7/31/2005,dry,5,FALSE,,,
+2005,Turkish Grand Prix,8/21/2005,dry,5,FALSE,,,
+2005,Italian Grand Prix,9/4/2005,dry,0,FALSE,,,
+2005,Belgian Grand Prix,9/11/2005,dry,7,TRUE,,,
+2005,Brazilian Grand Prix,9/25/2005,dry,5,FALSE,,,
+2005,Japanese Grand Prix,10/9/2005,dry,4,TRUE,1,,
+2005,Chinese Grand Prix,10/16/2005,dry,6,TRUE,2,,
+2006,Bahrain Grand Prix,3/12/2006,dry,4,FALSE,,,
+2006,Malaysian Grand Prix,3/19/2006,dry,8,FALSE,,,
+2006,Australian Grand Prix,4/2/2006,dry,10,TRUE,4,,
+2006,Emilia Romagna Grand Prix,4/3/2006,dry,6,TRUE,1,,
+2006,European Grand Prix,5/7/2006,dry,9,FALSE,,,
+2006,Spanish Grand Prix,5/14/2006,dry,6,FALSE,,,
+2006,Monaco Grand Prix,5/28/2006,dry,6,TRUE,1,,
+2006,British Grand Prix,6/11/2006,dry,4,FALSE,,,
+2006,Canadian Grand Prix,6/25/2006,dry,8,TRUE,,,
+2006,Indianapolis Grand Prix,7/2/2006,dry,13,TRUE,,,
+2006,French Grand Prix,7/16/2006,dry,6,FALSE,,,
+2006,German Grand Prix,7/30/2006,dry,8,FALSE,,,
+2006,Hungarian Grand Prix,8/6/2006,dry,8,FALSE,,,
+2006,Turkish Grand Prix,8/27/2006,dry,5,TRUE,,,
+2006,Italian Grand Prix,9/10/2006,dry,5,FALSE,,,
+2006,Chinese Grand Prix,10/1/2006,light_rain,5,FALSE,0,,
+2006,Japanese Grand Prix,10/8/2006,dry,5,FALSE,0,,
+2006,Brazilian Grand Prix,10/22/2006,dry,6,TRUE,,,
+2007,Australian Grand Prix,3/18/2007,dry,5,FALSE,0,,
+2007,Malaysian Grand Prix,4/8/2007,dry,4,FALSE,,,
+2007,Bahrain Grand Prix,4/15/2007,dry,7,TRUE,,,
+2007,Spanish Grand Prix,5/13/2007,dry,8,FALSE,,,
+2007,Monaco Grand Prix,5/27/2007,dry,4,FALSE,0,,
+2007,Canadian Grand Prix,6/10/2007,dry,8,TRUE,,,
+2007,Indianapolis Grand Prix,6/17/2007,dry,7,FALSE,,,
+2007,French Grand Prix,7/1/2007,dry,5,FALSE,,,
+2007,British Grand Prix,7/8/2007,dry,7,FALSE,,,
+2007,European Grand Prix,7/22/2007,heavy_rain,9,TRUE,,,
+2007,Hungarian Grand Prix,8/5/2007,dry,4,FALSE,,,
+2007,Turkish Grand Prix,8/26/2007,dry,2,FALSE,,,
+2007,Italian Grand Prix,9/9/2007,dry,2,TRUE,,,
+2007,Belgian Grand Prix,9/16/2007,dry,5,FALSE,,,
+2007,Japanese Grand Prix,9/30/2007,heavy_rain,10,TRUE,2,,
+2007,Chinese Grand Prix,10/7/2007,light_rain,5,FALSE,0,,
+2007,Brazilian Grand Prix,10/21/2007,dry,8,FALSE,,,
+2008,Australian Grand Prix,3/16/2008,dry,14,TRUE,3,,
+2008,Malaysian Grand Prix,4/23/2008,dry,5,FALSE,,,
+2008,Bahrain Grand Prix,4/6/2008,dry,3,FALSE,,,
+2008,Spanish Grand Prix,4/27/2008,dry,9,TRUE,,,
+2008,Turkish Grand Prix,5/11/2008,dry,3,TRUE,,,
+2008,Monaco Grand Prix,5/25/2008,light_rain,6,TRUE,2,,
+2008,Canadian Grand Prix,6/8/2008,dry,7,TRUE,,,
+2008,French Grand Prix,6/22/2008,light_rain,1,FALSE,,,
+2008,British Grand Prix,7/6/2008,heavy_rain,7,TRUE,,,
+2008,German Grand Prix,7/20/2008,dry,3,TRUE,,,
+2008,Hungarian Grand Prix,8/3/2008,dry,3,FALSE,,,
+2008,European Grand Prix,8/24/2008,dry,3,FALSE,,,
+2008,Belgian Grand Prix,9/7/2008,light_rain,4,FALSE,,,
+2008,Italian Grand Prix,9/14/2008,heavy_rain,1,TRUE,,,
+2008,Singapore Grand Prix,9/28/2008,dry,6,TRUE,,,
+2008,Japanese Grand Prix,10/12/2008,dry,5,FALSE,0,,
+2008,Chinese Grand Prix,10/19/2008,dry,3,FALSE,0,,
+2008,Brazilian Grand Prix,11/2/2008,heavy_rain,2,TRUE,,,
+2009,Australian Grand Prix,3/29/2009,dry,7,TRUE,2,,
+2009,Malaysian Grand Prix,4/5/2009,heavy_rain,5,TRUE,,,
+2009,Chinese Grand Prix,4/19/2009,heavy_rain,4,TRUE,2,,
+2009,Bahrain Grand Prix,4/26/2009,dry,1,FALSE,,,
+2009,Spanish Grand Prix,5/10/2009,dry,6,TRUE,,,
+2009,Monaco Grand Prix,5/24/2009,dry,6,FALSE,0,,
+2009,Turkish Grand Prix,6/7/2009,dry,2,FALSE,,,
+2009,British Grand Prix,6/21/2009,dry,2,FALSE,,,
+2009,German Grand Prix,7/12/2009,dry,2,FALSE,,,
+2009,Hungarian Grand Prix,7/26/2009,dry,3,FALSE,,,
+2009,European Grand Prix,8/23/2009,dry,3,FALSE,,,
+2009,Belgian Grand Prix,8/30/2009,dry,6,TRUE,,,
+2009,Italian Grand Prix,9/13/2009,dry,6,TRUE,,,
+2009,Singapore Grand Prix,9/27/2009,dry,6,TRUE,,,
+2009,Japanese Grand Prix,10/4/2009,dry,2,TRUE,1,,
+2009,Brazilian Grand Prix,10/18/2009,dry,6,TRUE,,,
+2009,Abu Dhabi Grand Prix,11/1/2009,dry,2,FALSE,,,
+2010,Bahrain Grand Prix,3/14/2010,dry,9,FALSE,,,
+2010,Australian Grand Prix,3/28/2010,light_rain,10,TRUE,1,,
+2010,Malaysian Grand Prix,4/4/2010,dry,7,FALSE,,,
+2010,Chinese Grand Prix,4/18/2010,light_rain,7,TRUE,2,,
+2010,Spanish Grand Prix,5/9/2010,dry,7,FALSE,,,
+2010,Monaco Grand Prix,5/16/2010,dry,12,TRUE,4,,
+2010,Turkish Grand Prix,5/30/2010,light_rain,5,FALSE,,,
+2010,Canadian Grand Prix,6/13/2010,dry,5,FALSE,,,
+2010,European Grand Prix,6/27/2010,dry,3,TRUE,,,
+2010,British Grand Prix,7/11/2010,dry,4,TRUE,,,
+2010,German Grand Prix,7/25/2010,dry,5,FALSE,,,
+2010,Hungarian Grand Prix,8/1/2010,dry,5,TRUE,,,
+2010,Belgian Grand Prix,8/29/2010,heavy_rain,4,TRUE,,,
+2010,Italian Grand Prix,9/12/2010,dry,5,FALSE,,,
+2010,Singapore Grand Prix,9/26/2010,dry,9,TRUE,,,
+2010,Japanese Grand Prix,10/10/2010,dry,8,TRUE,1,,
+2010,Korean Grand Prix,10/24/2010,heavy_rain,9,TRUE,,,
+2010,Brazilian Grand Prix,11/7/2010,dry,1,FALSE,,,
+2010,Abu Dhabi Grand Prix,11/14/2010,dry,4,TRUE,,,
+2011,Australian Grand Prix,3/27/2011,dry,7,FALSE,0,,
+2011,Malaysian Grand Prix,4/10/2011,dry,8,FALSE,,,
+2011,Chinese Grand Prix,4/17/2011,dry,1,FALSE,0,,
+2011,Turkish Grand Prix,5/8/2011,dry,2,FALSE,,,
+2011,Spanish Grand Prix,5/22/2011,dry,3,FALSE,,,
+2011,Monaco Grand Prix,5/29/2011,dry,7,TRUE,1,,
+2011,Canadian Grand Prix,6/12/2011,heavy_rain,7,TRUE,,,
+2011,European Grand Prix,6/26/2011,dry,0,FALSE,,,
+2011,British Grand Prix,7/10/2011,light_rain,5,FALSE,,,
+2011,German Grand Prix,7/24/2011,light_rain,4,FALSE,,,
+2011,Hungarian Grand Prix,7/31/2011,light_rain,4,FALSE,,,
+2011,Belgian Grand Prix,8/28/2011,dry,5,TRUE,,,
+2011,Italian Grand Prix,9/11/2011,dry,8,TRUE,,,
+2011,Singapore Grand Prix,9/25/2011,dry,4,TRUE,,,
+2011,Japanese Grand Prix,10/9/2011,dry,1,TRUE,1,,
+2011,Korean Grand Prix,10/16/2011,light_rain,3,TRUE,,,
+2011,Indian Grand Prix ,10/30/2011,dry,5,FALSE,,,
+2011,Abu Dhabi Grand Prix,11/13/2011,dry,4,FALSE,,,
+2011,Brazilian Grand Prix,11/27/2011,dry,4,FALSE,,,
+2012,Australian Grand Prix,3/18/2012,dry,9,TRUE,1,,
+2012,Malaysian Grand Prix,3/25/2012,heavy_rain,3,TRUE,,,
+2012,Chinese Grand Prix,4/15/2012,dry,1,FALSE,0,,
+2012,Bahrain Grand Prix,4/22/2012,dry,4,FALSE,,,
+2012,Spanish Grand Prix,5/13/2012,dry,5,FALSE,,,
+2012,Monaco Grand Prix,5/27/2012,light_rain,9,TRUE,1,,
+2012,Canadian Grand Prix,6/10/2012,dry,4,FALSE,,,
+2012,European Grand Prix,6/24/2012,dry,6,TRUE,,,
+2012,British Grand Prix,7/8/2012,dry,3,FALSE,,,
+2012,German Grand Prix,7/22/2012,dry,1,FALSE,,,
+2012,Hungarian Grand Prix,7/29/2012,dry,2,FALSE,,,
+2012,Belgian Grand Prix,9/2/2012,dry,6,TRUE,,,
+2012,Italian Grand Prix,9/9/2012,dry,5,FALSE,,,
+2012,Singapore Grand Prix,9/23/2012,dry,6,TRUE,,,
+2012,Japanese Grand Prix,10/7/2012,dry,6,TRUE,1,,
+2012,Korean Grand Prix,10/14/2012,dry,4,FALSE,,,
+2012,Indian Grand Prix ,10/28/2012,dry,3,FALSE,,,
+2012,Abu Dhabi Grand Prix,11/4/2012,dry,7,TRUE,,,
+2012,United States Grand Prix,11/18/2012,dry,2,FALSE,,,
+2012,Brazilian Grand Prix,11/25/2012,heavy_rain,6,TRUE,,,
+2013,Australian Grand Prix,3/17/2013,dry,4,FALSE,0,,
+2013,Malaysian Grand Prix,3/24/2013,light_rain,6,FALSE,,,
+2013,Chinese Grand Prix,4/14/2013,dry,4,FALSE,0,,
+2013,Bahrain Grand Prix,4/21/2013,dry,1,FALSE,,,
+2013,Spanish Grand Prix,5/12/2013,dry,3,FALSE,,,
+2013,Monaco Grand Prix,5/26/2013,dry,7,TRUE,3,,
+2013,Canadian Grand Prix,6/9/2013,dry,3,FALSE,,,
+2013,British Grand Prix,6/30/2013,dry,4,TRUE,,,
+2013,German Grand Prix,7/7/2013,dry,3,TRUE,,,
+2013,Hungarian Grand Prix,7/28/2013,dry,5,FALSE,,,
+2013,Belgian Grand Prix,8/25/2013,dry,3,FALSE,,,
+2013,Italian Grand Prix,9/8/2013,dry,2,FALSE,,,
+2013,Singapore Grand Prix,9/22/2013,dry,3,TRUE,,,
+2013,Korean Grand Prix,10/6/2013,dry,5,TRUE,,,
+2013,Japanese Grand Prix,10/13/2013,dry,3,FALSE,0,,
+2013,Indian Grand Prix ,10/27/2013,dry,4,FALSE,,,
+2013,Abu Dhabi Grand Prix,11/3/2013,dry,1,FALSE,,,
+2013,United States Grand Prix,11/17/2013,dry,1,TRUE,,,
+2013,Brazilian Grand Prix,11/24/2013,dry,3,FALSE,,,
+2014,Australian Grand Prix,3/16/2014,dry,7,TRUE,1,,
+2014,Malaysian Grand Prix,3/30/2014,dry,6,FALSE,,,
+2014,Bahrain Grand Prix,4/6/2014,dry,6,TRUE,,,
+2014,Chinese Grand Prix,4/20/2014,dry,2,FALSE,0,,
+2014,Spanish Grand Prix,5/11/2014,dry,2,FALSE,,,
+2014,Monaco Grand Prix,5/25/2014,dry,7,TRUE,2,,
+2014,Canadian Grand Prix,6/8/2014,dry,9,TRUE,,,
+2014,Austrian Grand Prix,6/22/2014,dry,3,FALSE,,,
+2014,British Grand Prix,7/6/2014,dry,6,TRUE,,,
+2014,German Grand Prix,7/20/2014,dry,4,TRUE,,,
+2014,Hungarian Grand Prix,7/27/2014,light_rain,6,TRUE,,,
+2014,Belgian Grand Prix,8/24/2014,dry,5,FALSE,,,
+2014,Italian Grand Prix,9/7/2014,dry,2,FALSE,,,
+2014,Singapore Grand Prix,9/21/2014,dry,4,TRUE,,,
+2014,Japanese Grand Prix,10/5/2014,heavy_rain,2,TRUE,3,,
+2014,Russian Grand Prix,10/12/2014,dry,2,FALSE,,,
+2014,United States Grand Prix,11/2/2014,dry,3,TRUE,,,
+2014,Brazilian Grand Prix,11/9/2014,dry,2,FALSE,,,
+2014,Abu Dhabi Grand Prix,11/23/2014,dry,3,FALSE,,,
+2015,Monaco Grand Prix,5/24/2015,dry,3,TRUE,1,1,
+2015,Canadian Grand Prix,6/7/2015,dry,3,FALSE,,,
+2015,Bahrain Grand Prix,4/19/2015,dry,2,FALSE,,,
+2015,Spanish Grand Prix,5/10/2015,dry,2,FALSE,,,
+2015,Chinese Grand Prix,4/12/2015,dry,4,TRUE,1,0,
+2015,Australian Grand Prix,3/15/2015,dry,4,TRUE,1,0,
+2015,Malaysian Grand Prix,3/29/2015,dry,4,TRUE,,,
+2015,Austrian Grand Prix,6/21/2015,dry,6,TRUE,,,
+2015,British Grand Prix,7/5/2015,light_rain,6,TRUE,,,
+2015,Hungarian Grand Prix,7/26/2015,dry,5,TRUE,,,
+2015,Belgian Grand Prix,8/23/2015,dry,4,TRUE,,,
+2015,Italian Grand Prix,9/6/2015,dry,4,FALSE,,,
+2015,Singapore Grand Prix,9/20/2015,dry,5,TRUE,,,
+2015,Japanese Grand Prix,9/27/2015,dry,1,FALSE,0,0,
+2015,Russian Grand Prix,10/11/2015,dry,7,TRUE,,,
+2015,United States Grand Prix,10/25/2015,light_rain,8,TRUE,,,
+2015,Mexican Grand Prix,11/1/2015,dry,4,TRUE,,,
+2015,Brazilian Grand Prix,11/15/2015,dry,1,FALSE,,,
+2015,Abu Dhabi Grand Prix,11/29/2015,dry,1,FALSE,,,
+2016,Australian Grand Prix,3/20/2016,dry,5,TRUE,1,0,
+2016,Bahrain Grand Prix,4/3/2016,dry,3,FALSE,,,
+2016,Chinese Grand Prix,4/17/2016,dry,0,TRUE,1,0,
+2016,Russian Grand Prix,5/1/2016,dry,4,TRUE,,,
+2016,Spanish Grand Prix,5/15/2016,dry,5,TRUE,,,
+2016,Monaco Grand Prix,5/29/2016,light_rain,7,TRUE,1,4,
+2016,Canadian Grand Prix,6/12/2016,dry,3,TRUE,,,
+2016,Azerbaijan Grand Prix,6/19/2016,dry,4,FALSE,,,
+2016,Austrian Grand Prix,7/3/2016,dry,6,TRUE,,,
+2016,British Grand Prix,7/10/2016,light_rain,6,TRUE,,,
+2016,Hungarian Grand Prix,7/24/2016,dry,1,FALSE,,,
+2016,German Grand Prix,7/31/2016,dry,2,FALSE,,,
+2016,Belgian Grand Prix,8/28/2016,dry,5,TRUE,,,
+2016,Italian Grand Prix,9/4/2016,dry,4,FALSE,,,
+2016,Singapore Grand Prix,9/18/2016,dry,3,TRUE,,,
+2016,Malaysian Grand Prix,10/2/2016,dry,6,FALSE,,,
+2016,Japanese Grand Prix,10/9/2016,dry,0,FALSE,0,0,
+2016,United States Grand Prix,10/23/2016,dry,4,TRUE,,,
+2016,Mexican Grand Prix,10/30/2016,dry,1,TRUE,,,
+2016,Brazilian Grand Prix,11/13/2016,heavy_rain,5,TRUE,,,
+2016,Abu Dhabi Grand Prix,11/27/2016,dry,5,FALSE,,,
+2017,Australian Grand Prix,3/26/2017,dry,7,FALSE,0,0,
+2017,Chinese Grand Prix,4/9/2017,light_rain,5,TRUE,1,1,
+2017,Bahrain Grand Prix,4/16/2017,dry,6,TRUE,,,
+2017,Russian Grand Prix,4/30/2017,dry,3,TRUE,,,
+2017,Spanish Grand Prix,5/14/2017,dry,3,TRUE,,,
+2017,Monaco Grand Prix,5/28/2017,dry,7,TRUE,1,0,
+2017,Canadian Grand Prix,6/11/2017,dry,5,TRUE,,,
+2017,Azerbaijan Grand Prix,6/25/2017,dry,7,TRUE,,,
+2017,Austrian Grand Prix,7/9/2017,dry,4,FALSE,,,
+2017,British Grand Prix,7/16/2017,dry,2,TRUE,,,
+2017,Hungarian Grand Prix,7/30/2017,dry,4,TRUE,,,
+2017,Belgian Grand Prix,8/27/2017,dry,4,TRUE,,,
+2017,Italian Grand Prix,9/3/2017,dry,4,FALSE,,,
+2017,Singapore Grand Prix,9/17/2017,light_rain,8,TRUE,,,
+2017,Malaysian Grand Prix,10/1/2017,dry,1,FALSE,,,
+2017,Japanese Grand Prix,10/8/2017,dry,5,TRUE,1,1,
+2017,United States Grand Prix,10/22/2017,dry,4,FALSE,,,
+2017,Mexican Grand Prix,10/29/2017,dry,5,TRUE,,,
+2017,Brazilian Grand Prix,11/12/2017,dry,4,TRUE,,,
+2017,Abu Dhabi Grand Prix,11/26/2017,dry,2,FALSE,,,
+2018,Australian Grand Prix,3/25/2018,dry,5,TRUE,1,1,
+2018,Bahrain Grand Prix,4/8/2018,dry,3,TRUE,,,
+2018,Chinese Grand Prix,4/15/2018,dry,1,TRUE,1,0,
+2018,Azerbaijan Grand Prix,4/29/2018,dry,7,TRUE,,,
+2018,Spanish Grand Prix,5/13/2018,dry,6,TRUE,,,
+2018,Monaco Grand Prix,5/27/2018,dry,3,TRUE,0,1,
+2018,Canadian Grand Prix,6/10/2018,dry,3,TRUE,,,
+2018,French Grand Prix,6/24/2018,dry,5,TRUE,,,
+2018,Austrian Grand Prix,7/1/2018,dry,6,TRUE,,,
+2018,British Grand Prix,7/8/2018,dry,6,TRUE,,,
+2018,German Grand Prix,7/22/2018,light_rain,5,TRUE,,,
+2018,Hungarian Grand Prix,7/29/2018,dry,3,TRUE,,,
+2018,Belgian Grand Prix,8/26/2018,dry,5,TRUE,,,
+2018,Italian Grand Prix,9/2/2018,dry,3,TRUE,,,
+2018,Singapore Grand Prix,9/16/2018,dry,1,TRUE,,,
+2018,Russian Grand Prix,9/30/2018,dry,2,FALSE,,,
+2018,Japanese Grand Prix,10/7/2018,dry,3,TRUE,1,1,
+2018,United States Grand Prix,10/21/2018,dry,4,TRUE,,,
+2018,Mexican Grand Prix,10/28/2018,dry,4,TRUE,,,
+2018,Brazilian Grand Prix,11/11/2018,dry,2,FALSE,,,
+2018,Abu Dhabi Grand Prix,11/25/2018,dry,5,TRUE,,,
+2019,Australian Grand Prix,3/17/2019,dry,3,FALSE,0,0,
+2019,Bahrain Grand Prix,3/31/2019,dry,4,TRUE,,,
+2019,Chinese Grand Prix,4/14/2019,dry,3,TRUE,0,1,
+2019,Azerbaijan Grand Prix,4/28/2019,dry,4,TRUE,,,
+2019,Spanish Grand Prix,5/12/2019,dry,2,TRUE,,,
+2019,Monaco Grand Prix,5/26/2019,dry,1,TRUE,1,0,
+2019,Canadian Grand Prix,6/9/2019,dry,2,FALSE,,,
+2019,French Grand Prix,6/23/2019,dry,1,TRUE,,,
+2019,Austrian Grand Prix,6/30/2019,dry,0,FALSE,,,
+2019,British Grand Prix,7/14/2019,dry,3,TRUE,,,
+2019,German Grand Prix,7/28/2019,light_rain,7,TRUE,,,
+2019,Hungarian Grand Prix,8/4/2019,dry,1,FALSE,,,
+2019,Belgian Grand Prix,9/1/2019,dry,3,TRUE,,,
+2019,Italian Grand Prix,9/8/2019,dry,3,TRUE,,,
+2019,Singapore Grand Prix,9/22/2019,dry,3,TRUE,,,
+2019,Russian Grand Prix,9/29/2019,dry,5,TRUE,,,
+2019,Japanese Grand Prix,10/13/2019,dry,1,FALSE,0,0,
+2019,Mexican Grand Prix,10/27/2019,dry,2,TRUE,,,
+2019,United States Grand Prix,11/3/2019,dry,3,FALSE,,,
+2019,Brazilian Grand Prix,11/17/2019,dry,4,TRUE,,,
+2019,Abu Dhabi Grand Prix,12/1/2019,dry,1,FALSE,,,
+2020,Austrian Grand Prix,7/5/2020,dry,9,TRUE,,,
+2020,Austrian Grand Prix,7/12/2020,dry,3,TRUE,,,
+2020,Hungarian Grand Prix,7/19/2020,light_rain,1,FALSE,,,
+2020,British Grand Prix,8/2/2020,dry,3,TRUE,,,
+2020,British Grand Prix,8/9/2020,dry,1,FALSE,,,
+2020,Spanish Grand Prix,8/16/2020,dry,1,FALSE,,,
+2020,Belgian Grand Prix,8/30/2020,dry,3,TRUE,,,
+2020,Italian Grand Prix,9/6/2020,dry,4,TRUE,,,
+2020,Tuscan Grand Prix,9/13/2020,dry,8,TRUE,,,
+2020,Russian Grand Prix,9/27/2020,dry,2,TRUE,,,
+2020,Eifel Grand Prix,10/11/2020,dry,5,TRUE,,,
+2020,Portuguese Grand Prix,10/25/2020,dry,1,FALSE,,,
+2020,Emilia Romagna Grand Prix,11/1/2020,dry,5,TRUE,1,1,
+2020,Turkish Grand Prix,11/15/2020,heavy_rain,4,TRUE,,,
+2020,Bahrain Grand Prix,11/29/2020,dry,3,TRUE,,,
+2020,Bahrain Grand Prix,12/6/2020,dry,3,TRUE,,,
+2020,Abu Dhabi Grand Prix,12/13/2020,dry,1,TRUE,,,
+2021,Emilia Romagna Grand Prix,4/18/2021,heavy_rain,3,TRUE,2,0,
+2021,Bahrain Grand Prix,3/28/2021,dry,4,TRUE,,,
+2021,Qatar Grand Prix,11/21/2021,dry,2,TRUE,,,
+2021,Portuguese Grand Prix,5/2/2021,dry,1,TRUE,,,
+2021,Spanish Grand Prix,5/9/2021,dry,1,TRUE,,,
+2021,Monaco Grand Prix,5/23/2021,dry,2,FALSE,0,0,
+2021,Azerbaijan Grand Prix,6/6/2021,dry,4,TRUE,,,
+2021,Austrian Grand Prix,6/27/2021,light_rain,2,FALSE,,,
+2021,French Grand Prix,6/20/2021,dry,0,TRUE,,,
+2021,Austrian Grand Prix,7/4/2021,dry,1,TRUE,,,
+2021,British Grand Prix,7/18/2021,dry,2,TRUE,,,
+2021,Hungarian Grand Prix,8/1/2021,light_rain,7,TRUE,,,
+2021,Belgian Grand Prix,8/29/2021,heavy_rain,5,TRUE,,,
+2021,Dutch Grand Prix,9/5/2021,dry,2,FALSE,,,
+2021,Italian Grand Prix,9/12/2021,dry,5,TRUE,,,
+2021,Russian Grand Prix,9/26/2021,light_rain,2,FALSE,,,
+2021,Turkish Grand Prix,10/10/2021,light_rain,0,FALSE,,,
+2021,United States Grand Prix,10/24/2021,dry,3,TRUE,,,
+2021,Mexico City Grand Prix,11/7/2021,dry,2,TRUE,,,
+2021,Sao Paulo Grand Prix,11/14/2021,dry,2,TRUE,,,
+2021,Saudi Arabian Grand Prix,12/5/2021,dry,5,TRUE,,,
+2021,Abu Dhabi Grand Prix,12/12/2021,dry,4,TRUE,,,
+2022,Bahrain Grand Prix,3/20/2022,dry,2,TRUE,,,
+2022,Saudi Arabian Grand Prix,3/27/2022,dry,7,TRUE,,,
+2022,Australian Grand Prix,4/10/2022,dry,3,TRUE,2,2,
+2022,Emilia Romagna Grand Prix,4/24/2022,light_rain,2,TRUE,1,0,
+2022,Miami Grand Prix,5/8/2022,dry,4,TRUE,1,1,
+2022,Spanish Grand Prix,5/22/2022,dry,2,FALSE,,,
+2022,Monaco Grand Prix,5/29/2022,light_rain,3,TRUE,2,1,
+2022,Azerbaijan Grand Prix,6/12/2022,dry,5,TRUE,,,
+2022,Canadian Grand Prix,6/19/2022,dry,3,TRUE,,,
+2022,British Grand Prix,7/3/2022,dry,6,TRUE,,,
+2022,Austrian Grand Prix,7/10/2022,dry,3,TRUE,,,
+2022,French Grand Prix,7/24/2022,dry,5,TRUE,,,
+2022,Hungarian Grand Prix,7/31/2022,dry,1,TRUE,,,
+2022,Belgian Grand Prix,8/28/2022,dry,2,TRUE,,,
+2022,Dutch Grand Prix,9/4/2022,dry,2,TRUE,,,
+2022,Italian Grand Prix,9/11/2022,dry,4,TRUE,,,
+2022,Singapore Grand Prix,10/2/2022,light_rain,6,TRUE,,,
+2022,Japanese Grand Prix,10/9/2022,heavy_rain,2,TRUE,1,0,
+2022,United States Grand Prix,10/23/2022,dry,3,TRUE,,,
+2022,Mexico City Grand Prix,10/30/2022,dry,2,TRUE,,,
+2022,Sao Paulo Grand Prix,11/13/2022,dry,3,TRUE,,,
+2022,Abu Dhabi Grand Prix,11/20/2022,dry,3,FALSE,,,
+2023,Bahrain Grand Prix,3/5/2023,dry,3,TRUE,,,
+2023,Saudi Arabian Grand Prix,3/19/2023,dry,2,TRUE,,,
+2023,Australian Grand Prix,4/2/2023,dry,8,TRUE,2,0,
+2023,Azerbaijan Grand Prix,4/30/2023,dry,2,TRUE,,,
+2023,Miami Grand Prix,5/7/2023,dry,0,FALSE,0,0,
+2023,Monaco Grand Prix,5/28/2023,heavy_rain,2,FALSE,0,0,
+2023,Spanish Grand Prix,6/4/2023,dry,0,FALSE,,,
+2023,Canadian Grand Prix,6/18/2023,dry,2,TRUE,,,
+2023,Austrian Grand Prix,7/2/2023,dry,1,TRUE,,,
+2023,British Grand Prix,7/9/2023,dry,3,TRUE,,,
+2023,Hungarian Grand Prix,7/23/2023,dry,3,FALSE,,,
+2023,Belgian Grand Prix,7/30/2023,dry,2,TRUE,,,
+2023,Dutch Grand Prix,8/27/2023,light_rain,3,TRUE,,,
+2023,Italian Grand Prix,9/3/2023,dry,2,FALSE,,,
+2023,Singapore Grand Prix,9/17/2023,dry,4,TRUE,,,
+2023,Japanese Grand Prix,9/24/2023,dry,5,TRUE,1,1,
+2023,Qatar Grand Prix,10/8/2023,dry,2,TRUE,,,
+2023,United States Grand Prix,10/22/2023,dry,3,FALSE,,,
+2023,Mexico City Grand Prix,10/29/2023,dry,4,TRUE,,,
+2023,Sao Paulo Grand Prix,11/5/2023,dry,6,TRUE,,,
+2023,Las Vegas Grand Prix,11/19/2023,dry,3,TRUE,,,
+2023,Abu Dhabi Grand Prix,11/26/2023,dry,0,FALSE,,,
+2024,Bahrain Grand Prix,3/2/2024,dry,0,FALSE,,,
+2024,Saudi Arabian Grand Prix,3/9/2024,dry,2,TRUE,,,
+2024,Australian Grand Prix,3/24/2024,dry,3,TRUE,0,2,
+2024,Japanese Grand Prix,4/7/2024,dry,3,TRUE,1,0,
+2024,Chinese Grand Prix,4/21/2024,dry,3,TRUE,2,1,
+2024,Miami Grand Prix,5/5/2024,dry,1,TRUE,1,1,
+2024,Emilia Romagna Grand Prix,5/19/2024,dry,1,FALSE,0,0,
+2024,Monaco Grand Prix,5/26/2024,dry,4,TRUE,1,0,
+2024,Canadian Grand Prix,6/9/2024,light_rain,5,TRUE,,,
+2024,Spanish Grand Prix,6/23/2024,dry,0,FALSE,,,
+2024,Austrian Grand Prix,6/30/2024,dry,1,TRUE,,,
+2024,British Grand Prix,7/7/2024,light_rain,2,FALSE,,,
+2024,Hungarian Grand Prix,7/21/2024,dry,1,FALSE,,,
+2024,Belgian Grand Prix,7/28/2024,dry,2,FALSE,,,
+2024,Dutch Grand Prix,8/25/2024,dry,0,FALSE,,,
+2024,Italian Grand Prix,9/1/2024,dry,1,FALSE,,,
+2024,Azerbaijan Grand Prix,9/15/2024,dry,4,TRUE,,,
+2024,Singapore Grand Prix,9/22/2024,dry,2,FALSE,,,
+2024,United States Grand Prix,10/20/2024,dry,1,TRUE,,,
+2024,Mexico City Grand Prix,10/27/2024,dry,3,TRUE,,,
+2024,Sao Paulo Grand Prix,11/3/2024,heavy_rain,5,TRUE,,,
+2024,Las Vegas Grand Prix,11/23/2024,dry,2,FALSE,,,
+2024,Qatar Grand Prix,12/1/2024,dry,5,TRUE,,,
+2024,Abu Dhabi Grand Prix,12/8/2024,dry,4,TRUE,,,


### PR DESCRIPTION
- Added columns for number of safety cars (num_of_sc) and number of virtual safety cars (num_of_vsc).
- Filled safety car data for tracks: Australia, Japan, China, Miami, Imola, Monaco.
- Data source 1 : https://f1.fandom.com/wiki/Safety_Car (1993-2022).
- Data source 2 : https://www.lightsoutblog.com (2023-2024) + wikipedia for confirmation.
- Added silver background to column num_of_vsc from beginning until year 2015 (when the virtual safety car was introduced).
